### PR TITLE
call session.remove() before session.configure

### DIFF
--- a/sqlahelper.py
+++ b/sqlahelper.py
@@ -22,6 +22,7 @@ _zte = ZopeTransactionExtension()
 def set_default_engine(engine):
     engines.default = engine
     bases.default.metadata.bind = engine
+    sessions.default.remove()
     sessions.default.configure(bind=engine)
 
 def reset():

--- a/tests.py
+++ b/tests.py
@@ -75,6 +75,16 @@ class TestAddEngine(SQLAHelperTestCase):
         self.assertIsNone(sqlahelper.get_base().metadata.bind)
         self.assertIsNone(sqlahelper.get_engine())
 
+    def test_add_engine_twice(self):
+        db1 = sa.create_engine(self.db1.url)
+        db2 = sa.create_engine(self.db2.url)
+        sqlahelper.add_engine(db1)
+        self.assertIs(sqlahelper.get_session().bind, db1)
+        sqlahelper.add_engine(db2)
+        self.assertIs(sqlahelper.get_session().bind, db2)
+        self.assertIs(sqlahelper.get_session().bind, sqlahelper.sessions.default.registry.registry.value.bind)
+
+
 
 class TestDeclarativeBase(SQLAHelperTestCase):
     def test1(self):

--- a/tests.py
+++ b/tests.py
@@ -4,7 +4,6 @@ import tempfile
 import unittest
 
 import sqlalchemy as sa
-from sqlalchemy.engine.base import Engine
 import sqlalchemy.ext.declarative as declarative
 
 import sqlahelper


### PR DESCRIPTION
when scoped_session has threadlocal session, configure method doesn't apply configs to that.
that behavior confuses us very much mainly testing with sqlahelper.
