### PR TITLE
Rename the ZopeTransactionExtension to ZopeTransactionEvents.

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ application's contextual session, engines, and declarative base. This avoids
 circular dependencies between the application's model modules, and allows
 cooperating third-party libraries to use the session, base, and transaction.
 
-The contextual session is initialized with the ZopeTransactionExtension so that
+The contextual session is initialized with the ZopeTransactionEvents so that
 it can be used with transaction managers. This can be disabled if desired.
 
 **SQLAHelper is under a maintenance freeze.**  If you would like to maintain

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,7 +14,7 @@ session, base, and transaction. SQLAHelper does not try to hide or disguise the
 underlying SQLAlchemy objects; it merely provides a way to organize them.
 
 The contextual session is initialized with the popular
-ZopeTransactionExtension, which allows it to work with transaction managers
+ZopeTransactionEvents, which allows it to work with transaction managers
 like pyramid_tm_ and repoze.tm2_. A transaction manager provides automatic
 commit at the end of request processing, or rollback if an exception is raised
 or HTTP error status occurs. Some transaction managers can commit both SQL and

--- a/sqlahelper.py
+++ b/sqlahelper.py
@@ -1,7 +1,7 @@
 import sqlalchemy as sa
 import sqlalchemy.ext.declarative as declarative
 import sqlalchemy.orm as orm
-from zope.sqlalchemy import ZopeTransactionExtension
+from zope.sqlalchemy import ZopeTransactionEvents
 
 # Import only version 1 API with "import *"
 __all__ = ["add_engine", "get_base", "get_session", "get_engine"]
@@ -17,7 +17,7 @@ engines = AttributeContainer()
 bases = AttributeContainer()
 sessions = AttributeContainer()
 
-_zte = ZopeTransactionExtension()
+_zte = ZopeTransactionEvents()
 
 def set_default_engine(engine):
     engines.default = engine
@@ -68,7 +68,7 @@ def get_session():
         sqlahelper.get_session().configure(...)
 
     But if you do this, be careful about the 'ext' arg. If you pass it, the
-    ZopeTransactionExtension will be disabled and you won't be able to use this
+    ZopeTransactionEvents will be disabled and you won't be able to use this
     contextual session with transaction managers. To keep the extension active
     you'll have to re-add it as an argument. The extension is accessible under
     the semi-private variable ``_zte``. Here's an example of adding your own

--- a/tests.py
+++ b/tests.py
@@ -134,7 +134,7 @@ class TestDeclarativeBase(SQLAHelperTestCase):
         barney = Person(id=3, first_name=u"Barney", last_name=u"Rubble")
         betty = Person(id=4, first_name=u"Betty", last_name=u"Rubble")
         Session = sqlahelper.get_session()
-        Session.configure(extension=None)  # XXX Kludge for SQLAlchemy/ZopeTransactionExtension bug
+        Session.configure(extension=None)  # XXX Kludge for SQLAlchemy/ZopeTransactionEvents bug
         sess = Session()
         sess.add_all([fred, wilma, barney, betty])
         sess.commit()


### PR DESCRIPTION
Fixed the issue in this article
https://stackoverflow.com/questions/17059433/not-able-to-import-zopetransactionextension-from-command-line